### PR TITLE
Fixed bean loading order

### DIFF
--- a/src/main/java/nl/_42/autoconfig/Docker42DatabaseBean.java
+++ b/src/main/java/nl/_42/autoconfig/Docker42DatabaseBean.java
@@ -1,0 +1,26 @@
+package nl._42.autoconfig;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ *
+ */
+public class Docker42DatabaseBean {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(Docker42DatabaseBean.class);
+
+    @PostConstruct
+    public void postConstruct() {
+        LOGGER.info(">>> Configuring Docker 42");
+    }
+
+    @PreDestroy
+    public void preDestroy() {
+        LOGGER.info(">>> Tearing down Docker 42");
+    }
+
+}

--- a/src/main/java/nl/_42/autoconfig/Docker42DatabaseBeanLiquibaseDependencyPostProcessor.java
+++ b/src/main/java/nl/_42/autoconfig/Docker42DatabaseBeanLiquibaseDependencyPostProcessor.java
@@ -1,0 +1,33 @@
+package nl._42.autoconfig;
+
+import java.util.Arrays;
+
+import liquibase.integration.spring.SpringLiquibase;
+
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.BeanFactoryUtils;
+import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.util.StringUtils;
+
+/**
+ *
+ */
+public class Docker42DatabaseBeanLiquibaseDependencyPostProcessor implements BeanFactoryPostProcessor {
+
+    private final String docker42DatabaseBeanName;
+
+    public Docker42DatabaseBeanLiquibaseDependencyPostProcessor(final String docker42DatabaseBeanName) {
+        this.docker42DatabaseBeanName = docker42DatabaseBeanName;
+    }
+
+    @Override
+    public void postProcessBeanFactory(final ConfigurableListableBeanFactory beanFactory) throws BeansException {
+        Arrays.stream(BeanFactoryUtils.beanNamesForTypeIncludingAncestors(beanFactory, SpringLiquibase.class))
+                .map(beanFactory::getBeanDefinition)
+                .forEach(beanDefinition -> {
+                    String[] dependsOn = beanDefinition.getDependsOn();
+                    beanDefinition.setDependsOn(StringUtils.addStringToArray(dependsOn, docker42DatabaseBeanName));
+                });
+    }
+}


### PR DESCRIPTION
Fixed bean loading order by implementing a BeanFactoryPostProcessor and modifying the Docker42AutoConfiguration to check for the SpringLiquibase bean dependency so that it only loads when Liquibase is used (might not be entirely necessary depending on final requirements)