### PR TITLE
Docker Properties + documentation

### DIFF
--- a/src/main/java/nl/_42/autoconfig/Docker42AutoConfiguration.java
+++ b/src/main/java/nl/_42/autoconfig/Docker42AutoConfiguration.java
@@ -7,23 +7,52 @@ import org.springframework.boot.autoconfigure.condition.AllNestedConditions;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.liquibase.LiquibaseAutoConfiguration;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
+import org.springframework.context.annotation.Configuration;
 
+/**
+ * The auto-configuration is called because it is configured in the spring.factories
+ * file. This class is mentioned there under the org.springframework.boot.autoconfigure.EnableAutoConfiguration
+ * key. Note that this class consists of a number of parts:
+ * <ul>
+ *     <li>auto configuration class; entity that is called by spring based on its entry in spring.factories</li>
+ *     <li>configuration class; a wrapper to make sure the properties can be injected and eventually passed to
+ *     the bean</li>
+ *     <li>bean; the class that does the heavylifting, ie setting up and tearing down of the container</li>
+ *     <li>post processor; class guaranteeing that every bean is dependent on this bean, ascertaining that
+ *     this bean is processed first</li>
+ *     <li>condition; verifies that Spring Liquibase is available and will not run if it is missing.</li>
+ * </ul>
+ */
 @ConditionalOnProperty(prefix = "docker_42", name = "enabled", matchIfMissing = false)
 @AutoConfigureAfter({LiquibaseAutoConfiguration.class })
+@EnableConfigurationProperties(Docker42Properties.class)
 public class Docker42AutoConfiguration {
+
+    @Configuration
+    @EnableConfigurationProperties(Docker42Properties.class)
+    public static class Docker42Configuration {
+
+        private final Docker42Properties properties;
+
+        public Docker42Configuration(Docker42Properties properties) {
+            this.properties = properties;
+        }
+
+        @Bean
+        @Conditional(OnSpringLiquibaseCondition.class)
+        public Docker42DatabaseBean docker42DatabaseBean() {
+            return new Docker42DatabaseBean(properties);
+        }
+
+    }
 
     @Bean
     @Conditional(OnSpringLiquibaseCondition.class)
     public Docker42DatabaseBeanLiquibaseDependencyPostProcessor docker42DatabaseBeanLiquibaseDependencyPostProcessor() {
         return new Docker42DatabaseBeanLiquibaseDependencyPostProcessor("docker42DatabaseBean");
-    }
-
-    @Bean
-    @Conditional(OnSpringLiquibaseCondition.class)
-    public Docker42DatabaseBean docker42DatabaseBean() {
-        return new Docker42DatabaseBean();
     }
 
     static class OnSpringLiquibaseCondition extends AllNestedConditions {

--- a/src/main/java/nl/_42/autoconfig/Docker42DatabaseBean.java
+++ b/src/main/java/nl/_42/autoconfig/Docker42DatabaseBean.java
@@ -7,20 +7,27 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- *
+ * Responsible for the actual setting up and tearing down of the container. The setting up
+ * is triggered at @PostConstruct time. The tearing down is triggered at @PreDestroy time.
  */
 public class Docker42DatabaseBean {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(Docker42DatabaseBean.class);
 
+    private final Docker42Properties properties;
+
+    public Docker42DatabaseBean(Docker42Properties properties) {
+        this.properties = properties;
+    }
+
     @PostConstruct
     public void postConstruct() {
-        LOGGER.info(">>> Configuring Docker 42");
+        LOGGER.info(">>> Configuring Docker 42: " + properties.getImage());
     }
 
     @PreDestroy
     public void preDestroy() {
-        LOGGER.info(">>> Tearing down Docker 42");
+        LOGGER.info(">>> Tearing down Docker 42: " + properties.getImage());
     }
 
 }

--- a/src/main/java/nl/_42/autoconfig/Docker42DatabaseBeanLiquibaseDependencyPostProcessor.java
+++ b/src/main/java/nl/_42/autoconfig/Docker42DatabaseBeanLiquibaseDependencyPostProcessor.java
@@ -11,7 +11,8 @@ import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.util.StringUtils;
 
 /**
- *
+ * Class responsible for getting all bean factories to depend on the 'docker' bean, effectively guaranteeing
+ * the 'docker' bean to run first.
  */
 public class Docker42DatabaseBeanLiquibaseDependencyPostProcessor implements BeanFactoryPostProcessor {
 


### PR DESCRIPTION
Added documentation to classes

Added 'Docker' properties to Bean. Done by introducing a config wrapper in the auto-config, which injects the properties into the config. From there on the bean can be created with an instance of the properties.